### PR TITLE
Have number of installs axis starting at least at 0

### DIFF
--- a/src/main/resources/templates/ExtensionsResource/details.html
+++ b/src/main/resources/templates/ExtensionsResource/details.html
@@ -68,6 +68,7 @@
                     title: {
                         text: 'Installs'
                     },
+                    floor: 0,
                     plotLines: [{
                         value: 0,
                         width: 1,


### PR DESCRIPTION
currently, we have some lost space with negative values which by definition we will never reach.

![image](https://github.com/redhat-developer/vscode-marketplace-stats/assets/1105127/aa81899b-87fe-40b0-b218-933d15318a41)

I was not able to find a way to test if it is working correctly. i would need to create a fake VS Code extension and provide huge range of values starting close to 0 I guess.

At least, it doesn't force to start at 0, which would avoid potential problems when zooming:
![image](https://github.com/redhat-developer/vscode-marketplace-stats/assets/1105127/e30001c9-4298-4365-bab8-3ee73f0e5867)
